### PR TITLE
Don't do git cloning for dxpb anymore

### DIFF
--- a/master/tasks/main.yml
+++ b/master/tasks/main.yml
@@ -34,14 +34,6 @@
     group: _dxpb_import
     mode: 0755
 
-- name: Obtain initial Git checkout for {{ dxpb_master_repo_giturl }}
-  git:
-    repo: "{{ dxpb_master_repo_giturl }}"
-    dest: /var/cache/dxpb/repo
-    update: no
-    remote: dxpb-remote
-  become_user: _dxpb_import
-
 - name: Perform initial binary-bootstrap
   command: ./xbps-src binary-bootstrap
   args:

--- a/master/templates/dxpb-pkgimport-master.conf.j2
+++ b/master/templates/dxpb-pkgimport-master.conf.j2
@@ -1,1 +1,2 @@
 WRKDIR=/var/cache/dxpb/repo
+REPOREMOTE={{ dxpb_master_repo_giturl }}

--- a/slave/tasks/main.yml
+++ b/slave/tasks/main.yml
@@ -13,13 +13,13 @@
     group: _dxpb
     mode: 0755
 
-- name: Obtain package tree for builders
-  git:
-    repo: "{{ dxpb_repo_giturl }}"
-    dest: "{{ dxpb_slave_root }}/{{ item.name }}"
-    update: no
-    remote: dxpb-remote
-  become_user: _dxpb_build
+- name: Create package tree directory for builders
+  file:
+    path: "{{ dxpb_slave_root }}/{{ item.name }}"
+    state: directory
+    owner: _dxpb_build
+    group: _dxpb
+    mode: 0755
   with_list: "{{ dxpb_buildslaves }}"
   loop_control:
     label: "{{ item.name }}"

--- a/slave/templates/build-conf.j2
+++ b/slave/templates/build-conf.j2
@@ -1,3 +1,4 @@
 WRKDIR={{ dxpb_slave_root }}/{{ item.name }}
 ENDPOINT=tcp://{{ dxpb_master }}:5195
+REPOREMOTE={{ dxpb_repo_giturl }}
 WRKSPEC={{ item.host | default ("x86_64") }}:{{ item.target }}:{{ item.cost | default(100) }}{% if item.cross %}:cross{% endif %}


### PR DESCRIPTION
dxpb now handles this itself. Instead, set the knobs that decide where upstream can be found.

I'm more used to salt states, so please do check that I have not made stupid errors in my ansible, especially the creation of the repo directory (which still must happen for dxpb).