### PR TITLE
Enable logging on the server components

### DIFF
--- a/master/templates/dxpb-frontend.conf.j2
+++ b/master/templates/dxpb-frontend.conf.j2
@@ -1,1 +1,1 @@
-ARGS=" -g tcp://{{ dxpb_master_frontend_bind }}:5195"
+ARGS=" -Y -g tcp://{{ dxpb_master_frontend_bind }}:5195"

--- a/master/templates/dxpb-pkgimport-master.conf.j2
+++ b/master/templates/dxpb-pkgimport-master.conf.j2
@@ -1,2 +1,3 @@
 WRKDIR=/var/cache/dxpb/repo
 REPOREMOTE={{ dxpb_master_repo_giturl }}
+ARGS=-Y


### PR DESCRIPTION
Also want to create a conf file containing: `ARGS='-Y'` for `dxpb-hostdir-master` and `dxpb-grapher`.
Between the four of these, we get a full log capability.

Later, instead of turning off logs, I'd add log-levels in dxpb to allow us to lower verbosity.